### PR TITLE
Fix "Syntax error: redirection unexpected"

### DIFF
--- a/apt-mirror/generate.sh
+++ b/apt-mirror/generate.sh
@@ -17,7 +17,7 @@ codename="trusty"
 # Install Docker
 ###################################
 
-command -v docker || curl http://get.docker.com/ | sh
+command -v docker || curl https://get.docker.com/ | sh
 
 # Create source file : source.list
 ###################################


### PR DESCRIPTION
Docker now enforces https, if you try access that link with normal http you will get redirected which messes up the installation.